### PR TITLE
Add fsinfo mesh information to some __init__ calls

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          architecture: 'x64'
+          #architecture: 'x64'
       - name: Install dependencies
         run: |
           python -m pip install --progress-bar off --upgrade pip setuptools wheel

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.9'
-          architecture: 'x64'
+          #architecture: 'x64'
       - name: Install dependencies
         run: |
           python -m pip install --progress-bar off --upgrade pip setuptools wheel

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -56,7 +56,7 @@ jobs:
           name: doc-dev
           path: ./doc-dev
       - name: Deploy dev documentation
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./doc-dev

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.9
-          architecture: 'x64'
+          #architecture: 'x64'
       - name: Install package
         run: |
           python -m pip install --progress-bar off --upgrade pip setuptools wheel

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.9'
-          architecture: 'x64'
+          #architecture: 'x64'
       - name: Install dependencies
         run: |
           python -m pip install --progress-bar off --upgrade pip setuptools wheel

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          architecture: 'x64'
+          #architecture: 'x64'
       - name: Install package
         run: |
           python -m pip install --progress-bar off --upgrade pip setuptools wheel

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -51,4 +51,4 @@ jobs:
           fail_ci_if_error: true # optional (default = false)
           verbose: true # optional (default = false)
           token: ${{ secrets.CODECOV_TOKEN }}
-          slug: m-reuter/LaPy
+          slug: deep-mi/LaPy

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -43,7 +43,7 @@ jobs:
         run: pytest lapy --cov=lapy --cov-report=xml --cov-config=pyproject.toml
       - name: Upload to codecov
         if: ${{ matrix.os == 'ubuntu' && matrix.python-version == 3.9 }}
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           files: ./coverage.xml
           flags: unittests # optional

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -50,3 +50,5 @@ jobs:
           name: codecov-umbrella # optional
           fail_ci_if_error: true # optional (default = false)
           verbose: true # optional (default = false)
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: m-reuter/LaPy

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -65,6 +65,13 @@ exclude_patterns = [
 nitpicky = True
 nitpick_ignore = []
 
+show_warning_types = True
+suppress_warnings = [
+    # Ignore new warning in Sphinx 7.3.0 while pickling environment:
+    #   WARNING: cannot cache unpickable configuration value: 'sphinx_gallery_conf'
+    "config.cache",
+]
+
 # A list of ignored prefixes for module index sorting.
 modindex_common_prefix = [f"{package}."]
 

--- a/lapy/tria_mesh.py
+++ b/lapy/tria_mesh.py
@@ -856,7 +856,7 @@ class TriaMesh:
         # convert vkeep to index list
         vkeep = np.nonzero(vkeep)[0]
         # set new vertices and tria and re-init adj matrices
-        self.__init__(vnew, tnew)
+        self.__init__(vnew, tnew, self.fsinfo)
         return vkeep, vdel
 
     def refine_(self, it=1):
@@ -893,7 +893,7 @@ class TriaMesh:
             t4 = np.column_stack((e1, e2, e3))
             tnew = np.reshape(np.concatenate((t1, t2, t3, t4), axis=1), (-1, 3))
             # set new vertices and tria and re-init adj matrices
-            self.__init__(vnew, tnew)
+            self.__init__(vnew, tnew, self.fsinfo)
 
     def normal_offset_(self, d):
         """Move vertices along normal by distance ``d``.
@@ -1006,12 +1006,12 @@ class TriaMesh:
             idx = idx.reshape(-1)
             tnew = self.t
             tnew[np.ix_(idx, [1, 0])] = tnew[np.ix_(idx, [0, 1])]
-            self.__init__(self.v, tnew)
+            self.__init__(self.v, tnew, self.fsinfo)
             flipped = idx.sum()
         # flip orientation on all trias if volume is negative:
         if self.volume() < 0:
             tnew[:, [1, 2]] = tnew[:, [2, 1]]
-            self.__init__(self.v, tnew)
+            self.__init__(self.v, tnew, self.fsinfo)
             flipped = tnew.shape[0] - flipped
         return flipped
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     'numpy>=1.21',
     'plotly',
     'psutil',
-    'scipy<=1.12',
+    'scipy!=1.13.0',
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     'numpy>=1.21',
     'plotly',
     'psutil',
-    'scipy',
+    'scipy==1.12',
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     'numpy>=1.21',
     'plotly',
     'psutil',
-    'scipy==1.12',
+    'scipy<=1.12',
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
TriaMesh internally calls __init__ in some cases to re-initialize member variables, if inplace operations changed the meshes.
However, when these are called the fsinfo attribute is missing from the call to __init__ resulting in the information in fsinfo getting lost.

I personally, do not really like to use __init__ as a method of the class outside of its use as a constructor. This is probably an example why this would be the case. It makes some differences less explicit and sometimes errors can appear. Maybe it should be considered to move this initialization functionality into an independent method.